### PR TITLE
Safe yaml loading and dumping

### DIFF
--- a/baiji/serialization/__init__.py
+++ b/baiji/serialization/__init__.py
@@ -7,4 +7,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = '1.0.2'
+__version__ = '1.1.0'

--- a/baiji/serialization/test_yaml.py
+++ b/baiji/serialization/test_yaml.py
@@ -18,9 +18,9 @@ class TestYAML(unittest.TestCase):
     def test_yaml_safe_dump_raises_on_unsafe(self):
         self.assertRaises(
             yaml.SerializationSafetyError,
-            yaml.dumps, UnsafeToDump, safe_dump=True)
+            yaml.dumps, UnsafeToDump, safe=True)
 
     def test_yaml_safe_load_raises_on_unsafe(self):
         self.assertRaises(
             yaml.SerializationSafetyError,
-            yaml.loads, unsafe_to_load, safe_load=True)
+            yaml.loads, unsafe_to_load, safe=True)

--- a/baiji/serialization/test_yaml.py
+++ b/baiji/serialization/test_yaml.py
@@ -1,7 +1,5 @@
-from __future__ import absolute_import
-import yaml as pyyaml
 import unittest
-from baiji.serialization import yaml as baiji_yaml
+from baiji.serialization import yaml
 
 class UnsafeToDump(object):
     """Python classes should not by default be YAML dumpable in safe mode"""
@@ -12,17 +10,17 @@ unsafe_to_load = "!!python/name:baiji.serialization.test_yaml.UnsafeToDump ''\n"
 class TestYAML(unittest.TestCase):
 
     def test_yaml_unsafe_dumps(self):
-        self.assertEqual(baiji_yaml.dumps(UnsafeToDump), unsafe_to_load)
+        self.assertEqual(yaml.dumps(UnsafeToDump), unsafe_to_load)
 
     def test_yaml_unsafe_loads_uses_load(self):
-        self.assertEqual(baiji_yaml.loads(unsafe_to_load), UnsafeToDump)
+        self.assertEqual(yaml.loads(unsafe_to_load), UnsafeToDump)
 
     def test_yaml_safe_dump_raises_on_unsafe(self):
         self.assertRaises(
-            baiji_yaml.SerializationSafetyError,
-            baiji_yaml.dumps, UnsafeToDump, safe_dump=True)
+            yaml.SerializationSafetyError,
+            yaml.dumps, UnsafeToDump, safe_dump=True)
 
     def test_yaml_safe_load_raises_on_unsafe(self):
         self.assertRaises(
-            baiji_yaml.SerializationSafetyError,
-            baiji_yaml.loads, unsafe_to_load, safe_load=True)
+            yaml.SerializationSafetyError,
+            yaml.loads, unsafe_to_load, safe_load=True)

--- a/baiji/serialization/test_yaml.py
+++ b/baiji/serialization/test_yaml.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+import yaml as pyyaml
+import unittest
+from baiji.serialization import yaml as baiji_yaml
+
+class UnsafeToDump(object):
+    """Python classes should not by default be YAML dumpable in safe mode"""
+    pass
+
+unsafe_to_load = "!!python/name:baiji.serialization.test_yaml.UnsafeToDump ''\n"
+
+class TestYAML(unittest.TestCase):
+
+    def test_yaml_unsafe_dumps(self):
+        self.assertEqual(baiji_yaml.dumps(UnsafeToDump), unsafe_to_load)
+
+    def test_yaml_unsafe_loads_uses_load(self):
+        self.assertEqual(baiji_yaml.loads(unsafe_to_load), UnsafeToDump)
+
+    def test_yaml_safe_dump_raises_on_unsafe(self):
+        self.assertRaises(
+            baiji_yaml.SerializationSafetyError,
+            baiji_yaml.dumps, UnsafeToDump, safe_dump=True)
+
+    def test_yaml_safe_load_raises_on_unsafe(self):
+        self.assertRaises(
+            baiji_yaml.SerializationSafetyError,
+            baiji_yaml.loads, unsafe_to_load, safe_load=True)

--- a/baiji/serialization/yaml.py
+++ b/baiji/serialization/yaml.py
@@ -16,14 +16,7 @@ def load(f, *args, **kwargs):
 
 
 def loads(s, *args, **kwargs):
-    import yaml
-    safe_load = kwargs.pop('safe_load', False) # Perhaps default should be True?
-    if safe_load:
-        try:
-            return yaml.safe_load(s, *args, **kwargs)
-        except yaml.representer.RepresenterError as e:
-            raise SerializationSafetyError(*e.args)
-    return yaml.load(s, *args, **kwargs)
+    return _load(s, *args, **kwargs)
 
 
 def dumps(obj, *args, **kwargs):
@@ -54,6 +47,6 @@ def _load(f, *args, **kwargs):
     if safe_load:
         try:
             return yaml.safe_load(f, *args, **kwargs)
-        except yaml.representer.RepresenterError as e:
+        except yaml.constructor.ConstructorError as e:
             raise SerializationSafetyError(*e.args)
     return yaml.load(f, *args, **kwargs)

--- a/baiji/serialization/yaml.py
+++ b/baiji/serialization/yaml.py
@@ -32,7 +32,7 @@ def dumps(obj, *args, **kwargs):
             warnings.warn(
                 ('Unsafe YAML serialization. This will generate an error in the '
                  'future. Call with `safe=False` if you really want unsafe serialization.'),
-                warnings.DeprecationWarning, stacklevel=2
+                DeprecationWarning, stacklevel=2
             )
         # if safe_mode is None (not given) or False (explicitly set), fall back to unsafe behavior
         return yaml.dump(obj, *args, **kwargs)
@@ -52,7 +52,7 @@ def _dump(f, obj, *args, **kwargs):
             warnings.warn(
                 ('Unsafe YAML serialization. This will generate an error in the '
                  'future. Call with `safe=False` if you really want unsafe serialization.'),
-                warnings.DeprecationWarning, stacklevel=2
+                DeprecationWarning, stacklevel=2
             )
         # if safe_mode is None (not given) or False (explicitly set), fall back to unsafe behavior
         return yaml.dump(obj, f, *args, **kwargs)
@@ -70,7 +70,7 @@ def _load(f, *args, **kwargs):
             warnings.warn(
                 ('Unsafe YAML serialization. This will generate an error in the '
                  'future. Call with `safe=False` if you really want unsafe serialization.'),
-                warnings.DeprecationWarning, stacklevel=2
+                DeprecationWarning, stacklevel=2
             )
         # if safe_mode is None (not given) or False (explicitly set), fall back to unsafe behavior
         return yaml.load(f, *args, **kwargs)

--- a/baiji/serialization/yaml.py
+++ b/baiji/serialization/yaml.py
@@ -15,19 +15,31 @@ def load(f, *args, **kwargs):
 
 def loads(s, *args, **kwargs):
     import yaml
+    safe_load = kwargs.pop('safe_load', False) # Perhaps default should be True?
+    if safe_load:
+        return yaml.safe_load(s, *args, **kwargs)
     return yaml.load(s, *args, **kwargs)
 
 
 def dumps(obj, *args, **kwargs):
     import yaml
+    safe_dump = kwargs.pop('safe_dump', False) # Perhaps default should be True?
+    if safe_dump:
+        return yaml.safe_dump(obj, *args, **kwargs)
     return yaml.dump(obj, *args, **kwargs)
 
 
 def _dump(f, obj, *args, **kwargs):
     import yaml
+    safe_dump = kwargs.pop('safe_dump', False) # Perhaps default should be True?
+    if safe_dump:
+        return yaml.safe_dump(obj, f, *args, **kwargs)
     return yaml.dump(obj, f, *args, **kwargs)
 
 
 def _load(f, *args, **kwargs):
     import yaml
+    safe_load = kwargs.pop('safe_load', False) # Perhaps default should be True?
+    if safe_load:
+        return yaml.safe_load(f, *args, **kwargs)
     return yaml.load(f, *args, **kwargs)

--- a/baiji/serialization/yaml.py
+++ b/baiji/serialization/yaml.py
@@ -60,6 +60,7 @@ def _dump(f, obj, *args, **kwargs):
 
 def _load(f, *args, **kwargs):
     import yaml
+    import warnings
     safe_mode = kwargs.pop('safe', None)
     try:
         return yaml.safe_load(f, *args, **kwargs)

--- a/baiji/serialization/yaml.py
+++ b/baiji/serialization/yaml.py
@@ -21,32 +21,56 @@ def loads(s, *args, **kwargs):
 
 def dumps(obj, *args, **kwargs):
     import yaml
-    safe_dump = kwargs.pop('safe_dump', False) # Perhaps default should be True?
-    if safe_dump:
-        try:
-            return yaml.safe_dump(obj, *args, **kwargs)
-        except yaml.representer.RepresenterError as e:
+    import warnings
+    safe_mode = kwargs.pop('safe', None)
+    try:
+        return yaml.safe_dump(obj, *args, **kwargs)
+    except yaml.representer.RepresenterError as e:
+        if safe_mode:
             raise SerializationSafetyError(*e.args)
-    return yaml.dump(obj, *args, **kwargs)
+        if safe_mode is None:
+            warnings.warn(
+                ('Unsafe YAML serialization. This will generate an error in the '
+                 'future. Call with `safe=False` if you really want unsafe serialization.'),
+                warnings.DeprecationWarning, stacklevel=2
+            )
+        # if safe_mode is None (not given) or False (explicitly set), fall back to unsafe behavior
+        return yaml.dump(obj, *args, **kwargs)
+
 
 
 def _dump(f, obj, *args, **kwargs):
     import yaml
-    safe_dump = kwargs.pop('safe_dump', False) # Perhaps default should be True?
-    if safe_dump:
-        try:
-            return yaml.safe_dump(obj, f, *args, **kwargs)
-        except yaml.representer.RepresenterError as e:
+    import warnings
+    safe_mode = kwargs.pop('safe', None)
+    try:
+        return yaml.safe_dump(obj, f, *args, **kwargs)
+    except yaml.representer.RepresenterError as e:
+        if safe_mode:
             raise SerializationSafetyError(*e.args)
-    return yaml.dump(obj, f, *args, **kwargs)
+        if safe_mode is None:
+            warnings.warn(
+                ('Unsafe YAML serialization. This will generate an error in the '
+                 'future. Call with `safe=False` if you really want unsafe serialization.'),
+                warnings.DeprecationWarning, stacklevel=2
+            )
+        # if safe_mode is None (not given) or False (explicitly set), fall back to unsafe behavior
+        return yaml.dump(obj, f, *args, **kwargs)
 
 
 def _load(f, *args, **kwargs):
     import yaml
-    safe_load = kwargs.pop('safe_load', False) # Perhaps default should be True?
-    if safe_load:
-        try:
-            return yaml.safe_load(f, *args, **kwargs)
-        except yaml.constructor.ConstructorError as e:
+    safe_mode = kwargs.pop('safe', None)
+    try:
+        return yaml.safe_load(f, *args, **kwargs)
+    except yaml.constructor.ConstructorError as e:
+        if safe_mode:
             raise SerializationSafetyError(*e.args)
-    return yaml.load(f, *args, **kwargs)
+        if safe_mode is None:
+            warnings.warn(
+                ('Unsafe YAML serialization. This will generate an error in the '
+                 'future. Call with `safe=False` if you really want unsafe serialization.'),
+                warnings.DeprecationWarning, stacklevel=2
+            )
+        # if safe_mode is None (not given) or False (explicitly set), fall back to unsafe behavior
+        return yaml.load(f, *args, **kwargs)

--- a/baiji/serialization/yaml.py
+++ b/baiji/serialization/yaml.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 EXTENSION = '.yaml'
 
+class SerializationSafetyError(Exception):
+    pass
 
 def dump(obj, f, *args, **kwargs):
     from baiji.serialization.util.openlib import ensure_file_open_and_call
@@ -17,7 +19,10 @@ def loads(s, *args, **kwargs):
     import yaml
     safe_load = kwargs.pop('safe_load', False) # Perhaps default should be True?
     if safe_load:
-        return yaml.safe_load(s, *args, **kwargs)
+        try:
+            return yaml.safe_load(s, *args, **kwargs)
+        except yaml.representer.RepresenterError as e:
+            raise SerializationSafetyError(*e.args)
     return yaml.load(s, *args, **kwargs)
 
 
@@ -25,7 +30,10 @@ def dumps(obj, *args, **kwargs):
     import yaml
     safe_dump = kwargs.pop('safe_dump', False) # Perhaps default should be True?
     if safe_dump:
-        return yaml.safe_dump(obj, *args, **kwargs)
+        try:
+            return yaml.safe_dump(obj, *args, **kwargs)
+        except yaml.representer.RepresenterError as e:
+            raise SerializationSafetyError(*e.args)
     return yaml.dump(obj, *args, **kwargs)
 
 
@@ -33,7 +41,10 @@ def _dump(f, obj, *args, **kwargs):
     import yaml
     safe_dump = kwargs.pop('safe_dump', False) # Perhaps default should be True?
     if safe_dump:
-        return yaml.safe_dump(obj, f, *args, **kwargs)
+        try:
+            return yaml.safe_dump(obj, f, *args, **kwargs)
+        except yaml.representer.RepresenterError as e:
+            raise SerializationSafetyError(*e.args)
     return yaml.dump(obj, f, *args, **kwargs)
 
 
@@ -41,5 +52,8 @@ def _load(f, *args, **kwargs):
     import yaml
     safe_load = kwargs.pop('safe_load', False) # Perhaps default should be True?
     if safe_load:
-        return yaml.safe_load(f, *args, **kwargs)
+        try:
+            return yaml.safe_load(f, *args, **kwargs)
+        except yaml.representer.RepresenterError as e:
+            raise SerializationSafetyError(*e.args)
     return yaml.load(f, *args, **kwargs)


### PR DESCRIPTION
This should really be the default way that we use YAML but I have currently let it default to the unsafe mode we have been using until now. This is just because I don't want to break stuff.
